### PR TITLE
Fix NPE's when foreign builders are not in use

### DIFF
--- a/lib/src/generator/generator.dart
+++ b/lib/src/generator/generator.dart
@@ -81,7 +81,7 @@ class ForeignCopyableLibraryGenerator extends Generator {
     });
 
     if (e == null) {
-      return "";
+      return null;
     }
 
     DartObject metaGenerator = e.computeConstantValue();
@@ -147,7 +147,7 @@ class ForeignCopierLibraryGenerator extends Generator {
     });
 
     if (e == null) {
-      return "";
+      return null;
     }
 
     DartObject metaGenerator = e.computeConstantValue();

--- a/lib/src/generator/generator.dart
+++ b/lib/src/generator/generator.dart
@@ -80,6 +80,10 @@ class ForeignCopyableLibraryGenerator extends Generator {
       }
     });
 
+    if (e == null) {
+      return "";
+    }
+
     DartObject metaGenerator = e.computeConstantValue();
     List<DartObject> copyableMetas = metaGenerator
         .getField('copyables')
@@ -141,6 +145,10 @@ class ForeignCopierLibraryGenerator extends Generator {
         return;
       }
     });
+
+    if (e == null) {
+      return "";
+    }
 
     DartObject metaGenerator = e.computeConstantValue();
     List<DartObject> copierMetas =
@@ -223,7 +231,7 @@ Class generateCopierClass({
       $baseClassName new$baseClassName = $baseClassName(
         ${fields.map((Parameter p) => '${p.name} : ${p.name} ?? master?.${p.name} ?? defaultMaster.${p.name}').toList().join(', ')}
       );
-      
+
       return resolve ? new$baseClassName : $newClassName(new$baseClassName);
     '''));
 
@@ -372,7 +380,7 @@ Class generateCopyableClass({
     ..body = Code('''
       master = master ?? this.master;
       $baseClassName new$baseClassName = $baseClassName($forwardParameters);
-      
+
       return $newClassName.from(new$baseClassName);
     '''));
 


### PR DESCRIPTION
This seems to fix https://github.com/kuanfajardo/copyable/issues/1. Returning empty strings or nulls when there's no `VariableElement` to be found seems to fix the issue.