### PR TITLE
Update dependencies to latest versions.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,12 +10,12 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  meta: ^1.1.6
+  meta: ^1.2.3
   # Generator
-  analyzer: ^0.36.3
-  build: ^1.1.4
-  source_gen: ^0.9.4
-  code_builder: ^3.2.0
+  analyzer: ^0.40.4
+  build: ^1.5.0
+  source_gen: ^0.9.7
+  code_builder: ^3.5.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Outdated dependencies cause issues when attempting to use this plugin together with other plugins such as json_serializable. These changes address such issues.